### PR TITLE
Add laravel 9 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,11 +13,16 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.0, 7.4]
-        laravel: [8.*]
+        laravel: [9.*,8.*]
         dependency-version: [prefer-lowest, prefer-stable]
+        exclude:
+          - laravel: 9.*
+            php: 7.4
         include:
           - laravel: 8.*
             testbench: 6.*
+          - laravel: 9.*
+            testbench: 7.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-unavatar` will be documented in this file
 
+## 0.3.0 - 2022-03-25
+
+- add Laravel 9 support
+
 ## 0.2.1 - 2020-12-20
 
 - fix namespace

--- a/composer.json
+++ b/composer.json
@@ -23,12 +23,12 @@
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
         "astrotomic/php-unavatar": "^0.2.0",
-        "illuminate/support": "^8.0",
-        "illuminate/view": "^8.0"
+        "illuminate/support": "^8.0|^9.0",
+        "illuminate/view": "^8.0|^9.0"
     },
     "require-dev": {
         "gajus/dindent": "^2.0",
-        "orchestra/testbench": "^6.0",
+        "orchestra/testbench": "^6.0|^7.0",
         "phpunit/phpunit": "^9.3"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,8 @@
 {
     "name": "astrotomic/laravel-unavatar",
-    "type": "library",
     "description": "Laravel integration of unavatar service.",
+    "license": "MIT",
+    "type": "library",
     "keywords": [
         "astrotomic",
         "laravel-unavatar",
@@ -9,8 +10,6 @@
         "unavatar",
         "avatar"
     ],
-    "homepage": "https://astrotomic.info",
-    "license": "MIT",
     "authors": [
         {
             "name": "Tom Witkowski",
@@ -19,27 +18,23 @@
             "role": "Developer"
         }
     ],
+    "homepage": "https://astrotomic.info",
+    "support": {
+        "email": "dev@astrotomic.info",
+        "issues": "https://github.com/Astrotomic/laravel-unavatar/issues",
+        "source": "https://github.com/Astrotomic/laravel-unavatar"
+    },
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
         "astrotomic/php-unavatar": "^0.2.0",
-        "illuminate/support": "^8.0|^9.0",
-        "illuminate/view": "^8.0|^9.0"
+        "illuminate/support": "^8.0 || ^9.0",
+        "illuminate/view": "^8.0 || ^9.0"
     },
     "require-dev": {
         "gajus/dindent": "^2.0",
-        "orchestra/testbench": "^6.0|^7.0",
+        "orchestra/testbench": "^6.0 || ^7.0",
         "phpunit/phpunit": "^9.3"
-    },
-    "config": {
-        "sort-packages": true
-    },
-    "extra": {
-        "laravel": {
-            "providers": [
-                "Astrotomic\\Unavatar\\Laravel\\UnavatarServiceProvider"
-            ]
-        }
     },
     "autoload": {
         "psr-4": {
@@ -51,13 +46,18 @@
             "Astrotomic\\Unavatar\\Laravel\\Tests\\": "tests"
         }
     },
+    "config": {
+        "sort-packages": true
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Astrotomic\\Unavatar\\Laravel\\UnavatarServiceProvider"
+            ]
+        }
+    },
     "scripts": {
         "test": "vendor/bin/phpunit",
         "test-coverage": "vendor/bin/phpunit --coverage-html coverage"
-    },
-    "support": {
-        "email": "dev@astrotomic.info",
-        "issues": "https://github.com/Astrotomic/laravel-unavatar/issues",
-        "source": "https://github.com/Astrotomic/laravel-unavatar"
     }
 }


### PR DESCRIPTION
In order to add support for laravel 9, this commit adds the necessary
version to the composer file as well as a new github workflow.